### PR TITLE
Adding last_action() Method and fixing bug in upsert after_save().

### DIFF
--- a/classes/mongo/document.php
+++ b/classes/mongo/document.php
@@ -147,6 +147,9 @@ abstract class Mongo_Document {
   const SAVE_UPDATE = 'update';
   const SAVE_UPSERT = 'upsert';
 
+  // Stores Last Save Action
+  protected $last_action = NULL;
+
   /**
    * Instantiate an object conforming to Mongo_Document conventions.
    * The document is not loaded until load() is called.
@@ -907,6 +910,16 @@ abstract class Mongo_Document {
   }
 
   /**
+   * Return last Save Action or NULL if no executed action
+   *
+   * @return  mixed  strings of constancts SAVE_INSERT, SAVE_UPDATE, SAVE_UPSERT or NULL
+   */
+  public function last_action()
+  {
+      return $this->last_action;
+  }
+
+  /**
    * Load the document from the database. The first parameter may be one of:
    *
    *  a falsey value - the object data will be used to construct the query
@@ -1057,6 +1070,8 @@ abstract class Mongo_Document {
 
     $this->_changed = $this->_operations = array();
 
+    $this->after_save = $action;
+
     $this->after_save($action);
 
     return $this;
@@ -1125,7 +1140,9 @@ abstract class Mongo_Document {
       throw new MongoException('Cannot upsert '.get_class($this).': no criteria');
     }
 
-    $this->before_save(self::SAVE_UPSERT);
+    $action = self::SAVE_UPSERT;
+
+    $this->before_save($action);
 
     $operations = self::array_merge_recursive_distinct($this->_operations, $operations);
 
@@ -1137,7 +1154,9 @@ abstract class Mongo_Document {
 
     $this->_changed = $this->_operations = array();
 
-    $this->after_save();
+    $this->after_save = $action;
+
+    $this->after_save($action);
 
     return $this;
   }


### PR DESCRIPTION
1. last_action property is setted after before_save() and just before after_save()
2. Even when is not the best option I am keeping the argument to ensure API backward compatibility.

Thanks!

Sebicas
