### PR TITLE
Added SYSPATH check

### DIFF
--- a/classes/controller/mongotest.php
+++ b/classes/controller/mongotest.php
@@ -1,5 +1,7 @@
 <?php
 
+defined('SYSPATH') or die('No direct script access.');
+
 /* Row Data Gateway Pattern */
 class Model_Document_Collection extends Mongo_Collection {
   protected $name = 'mongotest';

--- a/classes/json.php
+++ b/classes/json.php
@@ -1,4 +1,7 @@
 <?php
+
+defined('SYSPATH') or die('No direct script access.');
+
 /**
  * This json wrapper is included to provide a lenient decode method.
  *

--- a/classes/mongo/collection.php
+++ b/classes/mongo/collection.php
@@ -1,4 +1,7 @@
 <?php
+
+defined('SYSPATH') or die('No direct script access.');
+
 /**
  * This class can be used in any of the following ways:
  *

--- a/classes/mongo/database.php
+++ b/classes/mongo/database.php
@@ -1,4 +1,7 @@
 <?php
+
+defined('SYSPATH') or die('No direct script access.');
+
 /**
  * This class wraps the functionality of Mongo (connection) and MongoDB (database object) into one class.
  * When used with Kohana it can be instantiated simply by:

--- a/classes/mongo/document.php
+++ b/classes/mongo/document.php
@@ -1,4 +1,7 @@
 <?php
+
+defined('SYSPATH') or die('No direct script access.');
+
 /**
  * This class objectifies a Mongo document and can be used with one of the following design patterns:
  *

--- a/config/mongo.php
+++ b/config/mongo.php
@@ -1,4 +1,7 @@
 <?php
+
+defined('SYSPATH') or die('No direct script access.');
+
 /*
  * See http://www.php.net/manual/en/mongo.construct.php for configuration options.
  */


### PR DESCRIPTION
All classes in Kohana should start with the following statements

`defined('SYSPATH') or die('No direct script access.');`
