### PR TITLE
fixed using a boolean for MongoCollection::remove's second option

### DIFF
--- a/classes/mongo/document.php
+++ b/classes/mongo/document.php
@@ -1167,7 +1167,7 @@ abstract class Mongo_Document {
     $this->before_delete();
     $criteria = array('_id' => $this->_object['_id']);
 
-    if( ! $this->collection()->remove($criteria, TRUE))
+    if( ! $this->collection()->remove($criteria, array('justOne' => true)))
     {
       throw new MongoException('Failed to delete '.get_class($this));
     }


### PR DESCRIPTION
In version 1.0.5, some of the MongoDB driver's methods were changed to take arrays instead of scalar options.  In 1.2.11, providing a scalar now emits an E_DEPRECATED error.

There was one location (that I could find) that was still using the scalar (boolean) argument to MongoCollection::remove.  This pull request changes it to use the array form instead.

Note that all other calls to this function are already using an array.
