### PR TITLE
Fallback to old Mongo() class if MongoClient() is not found

### DIFF
--- a/classes/mongo/database.php
+++ b/classes/mongo/database.php
@@ -183,7 +183,7 @@ class Mongo_Database {
                 ? $config['server']
                 : "mongodb://".ini_get('mongo.default_host').":".ini_get('mongo.default_port');
 
-    $this->_connection = new MongoClient($server, $options);
+    $this->_connection = class_exists('MongoClient') ? new MongoClient($server, $options) :  new Mongo($server, $options);
 
     // Save the database name for later use
     $this->_db = $config['database'];


### PR DESCRIPTION
This is related to https://github.com/colinmollenhour/mongodb-php-odm/pull/44.
On dev machines it's easy to get the last MongoDB PHP driver but on production servers, this PHP driver is not necessary at the last version.
This small fix allows to use either MongoClient() or Mongo() as a fallback.
