### PR TITLE
Fixed Mongo_Collection::remove_safe

### DIFF
--- a/classes/mongo/collection.php
+++ b/classes/mongo/collection.php
@@ -748,12 +748,14 @@ class Mongo_Collection implements Iterator, Countable
    *
    * Returns number of documents removed if "safe", otherwise just if the operation was successfully sent.
    *
-   * @param array $criteria
-   * @param array $options
+   * [!!] Note: You cannot use this method with a capped collection.
+   *
+   * @param array $criteria  Description of records to remove [Optional]
+   * @param array $options   Options for remove [Optional]
    * @return bool|int
    * @throws MongoException on error
    */
-  public function remove_safe($criteria, $options = array())
+  public function remove_safe(array $criteria = array(), array $options = array())
   {
     $options = array_merge(array('safe' => TRUE, 'justOne' => FALSE), $options);
     $result = $this->remove($criteria, $options);


### PR DESCRIPTION
The main idea is that the `$criteria` param may be empty, in this case Mongo should remove all documents from collection.

Also I have made more strict list of accepted arguments, and amended PHPDoc docblock.
- http://docs.mongodb.org/manual/reference/method/db.collection.remove/
- http://www.php.net/manual/en/mongocollection.remove.php
