### PR TITLE
Mongo_Database::$configs got replaced in one of the pull requests

### DIFF
--- a/classes/mongo/database.php
+++ b/classes/mongo/database.php
@@ -79,8 +79,6 @@ class Mongo_Database {
    *  @static  array */
   protected static $instances = array();
 
-  public static $configs = array();
-
   /**
    * @var   string     default db to use
    */
@@ -112,11 +110,7 @@ class Mongo_Database {
     {
       if ($config === NULL)
       {
-        if (isset(self::$configs[$name]))
-        {
-          $config = self::$configs[$name];
-          if ($config instanceof Closure) $config = $config($name);
-        } else if (class_exists('Kohana'))
+        if (class_exists('Kohana'))
         {
           // Load the configuration for this database
           $config = Kohana::$config->load('mongo')->$name;


### PR DESCRIPTION
Mongo_Database::$configs was there to provide external static configuration - for those who don't use it in Kohana.
This commit 062d6c16e3e2612ce15f7339bf55e85002f038fd made it a protected property - essentially disabling this feature.

@sergeyklay, could you comment why you did this?
